### PR TITLE
Update BobPath code for trigger in step6.md

### DIFF
--- a/docs/step6.md
+++ b/docs/step6.md
@@ -92,7 +92,7 @@ Below is what the Command dynamic content should look like.
 
 | Variable Name | Value |
 | --- | --- |
-| BlobPath | `javascript @replace(trigger().outputs.body.folderPath, 'usage-preliminary/', '')` |
+| BlobPath | `@substring(trigger().outputs.body.folderPath, 18) |
 | BlobName | `@trigger().outputs.body.fileName` |
 
    * Click **Save** and **Publish all** of your changes


### PR DESCRIPTION
With the code:
`javascript @replace(trigger().outputs.body.folderPath, 'usage-preliminary/', '')`
even though the trigger itself can be triggered successfully, this results in an error for the subsequence pipeline run as follows:
`"The required Blob is missing. Folder path: usage-preliminary/javascript @replace(@item()?.pipelineParameters?.folderPath, 'usage-preliminary/', '')/.,Source=Microsoft.DataTransfer.ClientLibrary,'"`

It seems the path is incorrect and the javascript is not working.
Change the javascript for the trigger parameter's BlobPath value to `@substring(trigger().outputs.body.folderPath, 18)` resolves the error.